### PR TITLE
allow users to launch the container with a custom command

### DIFF
--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -50,36 +50,39 @@ log () {
   echo -e "\033[0;33m$(date "+%H:%M:%S")\033[0;37m ==> $1."
 }
 
-if ! app_present; then
-  log "Creating express application"
-  express . -f
-fi
-
-if ! dependencies_up_to_date; then
-  log "Installing/Updating Express dependencies (npm)"
-  npm install
-  log "Dependencies updated"
-fi
-
-if database_tier_exists; then
-  wait_for_db
-fi
-
-if ! fresh_container; then
-  echo "#########################################################################"
-  echo "                                                                       "
-  echo " App initialization skipped:"
-  echo " Delete the file $INIT_SEM and restart the container to reinitialize"
-  echo " You can alternatively run specific commands using docker-compose exec"
-  echo " e.g docker-compose exec myapp npm install angular"
-  echo "                                                                       "
-  echo "#########################################################################"
-else
-  if database_tier_exists; then
-    setup_db
+if [ "$1" == npm -a "$2" == "start" ]; then
+  if ! app_present; then
+    log "Creating express application"
+    express . -f
   fi
-  log "Initialization finished"
+
+  if ! dependencies_up_to_date; then
+    log "Installing/Updating Express dependencies (npm)"
+    npm install
+    log "Dependencies updated"
+  fi
+
+  if database_tier_exists; then
+    wait_for_db
+  fi
+
+  if ! fresh_container; then
+    echo "#########################################################################"
+    echo "                                                                       "
+    echo " App initialization skipped:"
+    echo " Delete the file $INIT_SEM and restart the container to reinitialize"
+    echo " You can alternatively run specific commands using docker-compose exec"
+    echo " e.g docker-compose exec myapp npm install angular"
+    echo "                                                                       "
+    echo "#########################################################################"
+  else
+    if database_tier_exists; then
+      setup_db
+    fi
+    log "Initialization finished"
+  fi
+
+  touch $INIT_SEM
 fi
 
-touch $INIT_SEM
 exec /entrypoint.sh "$@"


### PR DESCRIPTION
The `app-entrypoint.sh` performs the container setup bits only if the
specified command is prefixed with `bundle exec`. In other cases the
specified command is launched without any container initializations.

f.e. `docker run -it --rm express bash` will start the `bash` command
inside the container.