### PR TITLE
Prevent "stdin: is not a tty" error message

### DIFF
--- a/.codenvy.dockerfile
+++ b/.codenvy.dockerfile
@@ -31,4 +31,4 @@ ENV TERM=xterm
 ENV DATABASE_URL=mongodb://localhost:27017/my_project_development
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["sudo", "-i", "harpoon", "start", "--foreground", "mongodb"]
+CMD ["sudo", "env", "HOME=/root", "harpoon", "start", "--foreground", "mongodb"]


### PR DESCRIPTION
'sudo -i' runs the shell specified by the target user's password database entry as a login shell. This executes the .profile in /root but this includes a call to 'mesg', which assumes a TTY is present. This makes a "stdin: is not a tty" error message appear in the output of the initialization of the container on Eclipse Che.